### PR TITLE
[#23] Render resource view descriptions as Markdown.

### DIFF
--- a/ckanext/pdfview/tests/test_view.py
+++ b/ckanext/pdfview/tests/test_view.py
@@ -21,7 +21,7 @@ def _create_test_view(view_type):
     resource_view = {'resource_id': resource_id,
                      'view_type': view_type,
                      'title': u'Test View',
-                     'description': u'A nice test view'}
+                     'description': u'A *nice* test view'}
     resource_view = plugins.toolkit.get_action('resource_view_create')(
         context, resource_view)
     return resource_view, package, resource_id
@@ -81,5 +81,10 @@ class TestPdfView(tests.WsgiAppCase):
                         id=self.package.name, resource_id=self.resource_id)
         result = self.app.get(url)
         assert self.resource_view['title'] in result
-        assert self.resource_view['description'] in result
         assert 'data-module="data-viewer"' in result.body
+
+    def test_description_supports_markdown(self):
+        url = h.url_for(controller='package', action='resource_read',
+                        id=self.package.name, resource_id=self.resource_id)
+        result = self.app.get(url)
+        assert 'A <em>nice</em> test view' in result

--- a/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
@@ -9,7 +9,7 @@
     <i class="icon-code"></i>
     {{ _("Embed") }}
   </a>
-  <p class="desc">{{ resource_view['description'] }}</p>
+  <p class="desc">{{ h.render_markdown(resource_view['description']) }}</p>
   <div class="m-top ckanext-datapreview">
     {% if not to_preview and h.resource_view_is_filterable(resource_view) %}
       {% snippet 'package/snippets/resource_view_filters.html', resource=resource %}


### PR DESCRIPTION
Fixes #23. This is actually the same fix as ckan/ckan#3129 (which fixes ckan/ckan#3128, the source of #23).
