### PR TITLE
[#27] Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: python
 sudo: required
 python:
     - "2.7"
+env:
+    - CKANVERSION=master
+    - CKANVERSION=2.7
+    - CKANVERSION=2.6
+    - CKANVERSION=2.5
+    - CKANVERSION=2.4
+    - CKANVERSION=2.3
 services:
     - postgresql
     - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 sudo: required
 python:
     - "2.7"
-env: PGVERSION=9.1
-install:
-    - bash bin/travis-build.bash
-    - pip install coveralls
+services:
+    - postgresql
+    - redis-server
+install: bash bin/travis-build.bash
 script: sh bin/travis-run.sh
 after_success:
     - coveralls

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -5,15 +5,25 @@ echo "This is travis-build.bash..."
 
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install postgresql-$PGVERSION solr-jetty libcommons-fileupload-java:amd64=1.2.2-1
+sudo apt-get install solr-jetty
 
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
 python setup.py develop
-pip install -r requirements.txt --allow-all-external
-pip install -r dev-requirements.txt --allow-all-external
+pip install -r requirements.txt
+pip install -r dev-requirements.txt
 cd -
+
+echo "Setting up Solr..."
+# Solr is multicore for tests on CKAN master now, but it's easier to run tests
+# on Travis single-core still. See https://github.com/ckan/ckan/issues/2972
+sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+
+echo "Setting up Jetty..."
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo service jetty restart
 
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -10,6 +10,14 @@ sudo apt-get install solr-jetty
 echo "Installing CKAN and its Python dependencies..."
 git clone https://github.com/ckan/ckan
 cd ckan
+if [ $CKANVERSION == 'master' ]
+then
+    echo "CKAN version: master"
+else
+    CKAN_TAG=$(git tag | grep ^ckan-$CKANVERSION | sort --version-sort | tail -n 1)
+    git checkout $CKAN_TAG
+    echo "CKAN version: ${CKAN_TAG#ckan-}"
+fi
 python setup.py develop
 pip install -r requirements.txt
 pip install -r dev-requirements.txt

--- a/bin/travis-run.sh
+++ b/bin/travis-run.sh
@@ -1,10 +1,10 @@
 #!/bin/sh -e
 
-# solr is multicore for tests on ckan master now, but it's easier to run tests
-# on Travis single-core still.
-# see https://github.com/ckan/ckan/issues/2972
-sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
-echo "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
-sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
-sudo service jetty restart
-nosetests --nologcapture --with-pylons=subdir/test.ini --with-coverage --cover-package=ckanext.pdfview --cover-inclusive --cover-erase --cover-tests ckanext/pdfview
+nosetests --ckan \
+          --nologcapture \
+          --with-pylons=subdir/test.ini \
+          --with-coverage \
+          --cover-package=ckanext.pdfview \
+          --cover-inclusive \
+          --cover-erase \
+          --cover-tests

--- a/ckanext/pdfview/tests/test_view.py
+++ b/ckanext/pdfview/tests/test_view.py
@@ -3,13 +3,17 @@ import pylons.config as config
 import urlparse
 
 import ckan.model as model
-import ckan.tests.legacy as tests
 import ckan.plugins as plugins
 import ckan.lib.helpers as h
 import ckanext.pdfview.plugin as plugin
 import ckan.lib.create_test_data as create_test_data
 import ckan.config.middleware as middleware
 
+try:
+    import ckan.tests.legacy as tests
+except ImportError:
+    # CKAN <= 2.3
+    import ckan.tests as tests
 
 def _create_test_view(view_type):
     context = {'model': model,


### PR DESCRIPTION
Fixes #27.

Fixes the Travis CI build and configures Travis to run the tests for all supported versions of CKAN (according to the README: CKAN >= 2.3).

