### PR TITLE
[#31] Fix Flask exception

### DIFF
--- a/ckanext/pdfview/plugin.py
+++ b/ckanext/pdfview/plugin.py
@@ -2,9 +2,12 @@ import logging
 
 import ckan.plugins as p
 import ckan.lib.datapreview as datapreview
+from ckan.common import is_flask_request
 
 log = logging.getLogger(__name__)
 
+def request_type():
+    return is_flask_request()
 
 class PdfView(p.SingletonPlugin):
     '''This extension views PDFs. '''
@@ -18,6 +21,7 @@ class PdfView(p.SingletonPlugin):
     p.implements(p.IConfigurer, inherit=True)
     p.implements(p.IConfigurable, inherit=True)
     p.implements(p.IResourceView, inherit=True)
+    p.implements(p.ITemplateHelpers)
 
     PDF = ['pdf', 'x-pdf', 'acrobat', 'vnd.pdf']
     proxy_is_enabled = False
@@ -52,3 +56,6 @@ class PdfView(p.SingletonPlugin):
 
     def view_template(self, context, data_dict):
         return 'pdf.html'
+
+    def get_helpers(self):
+        return {'pdfview_request_type': request_type}

--- a/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
@@ -34,6 +34,7 @@
         </p>
       </div>
       {% if not to_preview %}
+        {{ h.pdfview_request_type() }}
         {% set current_filters = request.str_GET.get('filters') %}
         {% if current_filters %}
           {% set src = h.url(qualified=true, controller='package',

--- a/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
@@ -34,23 +34,44 @@
         </p>
       </div>
       {% if not to_preview %}
-        {{ h.pdfview_request_type() }}
-        {% set current_filters = request.str_GET.get('filters') %}
-        {% if current_filters %}
-          {% set src = h.url(qualified=true, controller='package',
-                             action='resource_view', id=package['name'],
-                             resource_id=resource['id'],
-                             view_id=resource_view['id'],
-                             filters=current_filters)  %}
+        {% set is_flask = h.pdfview_request_type() %}
+        {# set current_filters correctly, depending on whether we are using flask or pylons #}
+        {% if is_flask %}
+          {% set current_filters = request.args.get('filters') %}
+          {% if current_filters %}
+            {% set src = h.url(qualified=true, controller='resource',
+                               action='view', id=package['name'],
+                               resource_id=resource['id'],
+                               view_id=resource_view['id'],
+                               filters=current_filters)  %}
+          {% else %}
+            {% set src = h.url(qualified=true, controller='resource',
+                              action='view', id=package['name'],
+                              resource_id=resource['id'],
+                              view_id=resource_view['id'])  %}
+          {% endif %}
         {% else %}
-          {% set src = h.url(qualified=true, controller='package',
-                             action='resource_view', id=package['name'],
-                             resource_id=resource['id'],
-                             view_id=resource_view['id'])  %}
+          {% set current_filters = request.str_GET.get('filters') %}
+          {% if current_filters %}
+            {% set src = h.url(qualified=true, controller='package',
+                               action='resource_view', id=package['name'],
+                               resource_id=resource['id'],
+                               view_id=resource_view['id'],
+                               filters=current_filters)  %}
+          {% else %}
+            {% set src = h.url(qualified=true, controller='package',
+                               action='resource_view', id=package['name'],
+                               resource_id=resource['id'],
+                               view_id=resource_view['id'])  %}
+          {% endif %}
         {% endif %}
       {% else %}
         {# When previewing we need to stick the whole resource_view as a param as there is no other way to pass to information on to the iframe #}
-        {% set src = h.url(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+        {% if is_flask %}
+          {% set src = h.url(qualified=true, controller='resource', action='view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+        {% else %}
+          {% set src = h.url(qualified=true, controller='package', action='resource_view', id=package['name'], resource_id=resource['id']) + '?' + h.urlencode({'resource_view': h.dump_json(resource_view)}) %}
+        {% endif %}
       {% endif %}
       <iframe src="{{ src }}" frameborder="0" width="100%" data-module="data-viewer" allowfullscreen>
         <p>{{ _('Your browser does not support iframes.') }}</p>


### PR DESCRIPTION
Fixes #31 

Adds a helper function to check whether a request is Flask or Pylons and use the appropriate function (`request.str_GET` vs `request.args`). Tested with CKAN 2.8.2 (which uses Pylons) and a CKAN instance running on CKAN commit #98f518c (because that's where my group's instance is). Starting with and after CKAN commit #5963647, the extension no longer throws the Flask exception, but it also does not work properly (the iframe for the PDF is displayed but the PDF itself is not). I believe this is due to a change in that commit in how javascript resources are accessed but I'm not able to look into it more at the moment. 