### PR TITLE
Hide modal with correct class

### DIFF
--- a/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
+++ b/ckanext/pdfview/theme/templates/package/snippets/resource_view.html
@@ -1,5 +1,7 @@
 {% import 'macros/form.html' as form %}
 
+{% set hide_modal_class = 'fade' if h.ckan_version() > '2.8' else 'hide' %}
+
 <div id="view-{{ resource_view['id'] }}" class="resource-view" data-id="{{ resource_view['id'] }}" data-title="{{ resource_view['title'] }}" data-description="{{ resource_view['descripion'] }}">
   <a class="btn pull-right"
      href="#embed-{{ resource_view['id'] }}"
@@ -56,7 +58,7 @@
       </iframe>
     {% endif %}
   </div>
-  <div id="embed-{{ resource_view['id'] }}" class="modal resource-view-embed hide">
+  <div id="embed-{{ resource_view['id'] }}" class="modal resource-view-embed {{ hide_modal_class }}">
     <div class="modal-header">
       <button type="button" class="close" data-dismiss="modal">&times;</button>
       <h3>{{ _("Embed resource view") }}</h3>


### PR DESCRIPTION
Starting with CKAN v2.8(bootstrap 3) modal blocks are using `fade` class instead of `hide`