### PR TITLE
call resource URL with preview flag

### DIFF
--- a/ckanext/pdfview/theme/templates/pdf_view.html
+++ b/ckanext/pdfview/theme/templates/pdf_view.html
@@ -1,3 +1,3 @@
-<object style="margin:auto; max-height:100%; min-height:100vh; min-width:100%; display:block" data="{{ resource_view.get('pdf_url') or resource.get('url') }}" type="application/pdf">
+<object style="margin:auto; max-height:100%; min-height:100vh; min-width:100%; display:block" data="{{ resource_view.get('pdf_url') or resource.get('url') }}?preview=1" type="application/pdf">
 	<p>{{ _('Your browser does not support object tags.') }}</p>
 </object>


### PR DESCRIPTION
This will allow storage engines that serve different headers for preview and download to serve the desired content. Other engines should ignore it.

Refs https://github.com/keitaroinc/ckanext-s3filestore/pull/2